### PR TITLE
Fix bug removing selected feature during SFFS floating step

### DIFF
--- a/main.ipynb
+++ b/main.ipynb
@@ -1177,6 +1177,8 @@
     "\n",
     "        # Floating step: Reconsider all selected features for elimination\n",
     "        for feature in list(selectedFeatures):\n",
+    "            if feature not in selectedFeatures:\n",
+    "                continue\n",
     "            tempSelectedFeatures = selectedFeatures.copy()\n",
     "            tempSelectedFeatures.remove(feature)  # Temporarily remove the feature\n",
     "\n",


### PR DESCRIPTION
## Summary
- prevent `ValueError` during SFFS by checking feature presence before removal

## Testing
- `python -m py_compile metrics.py utils.py mathFunctions.py printScore.py`

------
https://chatgpt.com/codex/tasks/task_e_688bca729fe0832baf364a6101fe57c5